### PR TITLE
Adjusted Storage Ignore Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,11 @@
 /vendor
 /node_modules
-/storage
 .vagrant
 .idea
 Homestead.yaml
 Homestead.json
 .env
 _ide_helper.php
-
 public/css
 public/js
 public/uploads

--- a/storage/framework/.gitignore
+++ b/storage/framework/.gitignore
@@ -1,0 +1,8 @@
+config.php
+routes.php
+schedule-*
+compiled.php
+services.json
+events.scanned.php
+routes.scanned.php
+down

--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/sessions/.gitignore
+++ b/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/views/.gitignore
+++ b/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/logs/.gitignore
+++ b/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Storage folder was ignored. It is important for it to be there, should there be cache storage, or logging involved in your app. 

Gitignores were added accordingly.
